### PR TITLE
Changes for standalone executable releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2020-07-03
+
+Changes for static builds.
+
+### Change
+
+  * Replace uses of `Paths_` library to use `file-embed`, so static builds can be
+    packaged/archived with just the binary and no other files
+  * Cabal project config for static building
+
 ## [0.5.0] - 2020-06-28
 
 Introduce the ability to open Gopher menu items with an external application

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -3,7 +3,6 @@ module Config where
 import           System.Directory
 import           System.FilePath
 
---import           Data.FileEmbed
 import           Data.ConfigFile
 
 -- | Basically `emptyCP`, but doesn't toLower the options.

--- a/src/Config/ConfigOpen.hs
+++ b/src/Config/ConfigOpen.hs
@@ -1,29 +1,25 @@
+ {-# LANGUAGE TemplateHaskell #-}
+
 -- | Config stuff for open associations...
 
 module Config.ConfigOpen where
 
---import           Data.Text.Encoding.Error       (lenientDecode)
---import           Data.Text.Encoding            as E
---import qualified Data.ByteString.Char8 as Char8
 import           System.FilePath
-import           System.Directory
+import qualified Data.ByteString.Lazy as BL
 
---import           Data.FileEmbed
+import           Data.FileEmbed
 import           Data.ConfigFile
 
 import           Config                            ( getConfigDirectory, readConfigParser, doIfPathDoesntExist )
-import           Paths_waffle
 
--- FIXME: check if file already exists
+defaultOpenConfig :: BL.ByteString
+defaultOpenConfig = BL.fromStrict $(embedFile "data/open.ini")
+
 -- TODO: maybe should be setupFactoryOpenConfig
 setupDefaultOpenConfig :: IO ()
 setupDefaultOpenConfig = do
   userOpenConfigPath <- getUserOpenConfigPath
-  defaultOpenConfigPath <- getDefaultOpenConfigPath
-  doIfPathDoesntExist userOpenConfigPath (copyFile defaultOpenConfigPath userOpenConfigPath)
-
-getDefaultOpenConfigPath :: IO FilePath
-getDefaultOpenConfigPath = getDataFileName "data/open.ini"
+  doIfPathDoesntExist userOpenConfigPath (BL.writeFile userOpenConfigPath defaultOpenConfig)
 
 -- | Get the `FilePath` to the user's open/associations configuration file.
 getUserOpenConfigPath :: IO FilePath
@@ -32,14 +28,6 @@ getUserOpenConfigPath = do
   pure $ joinPath [configDir, "open.ini"]
 
 -- | The default open.ini list of associations between item types and
--- commands to open them. This is the default config file included
--- with Waffle, not the user's config.
-getDefaultOpenConfig :: IO ConfigParser
-getDefaultOpenConfig = getDataFileName "data/open.ini" >>= readConfigParser
-
--- | The default open.ini list of associations between item types and
 -- commands to open them.
 getUserOpenConfig :: IO ConfigParser
 getUserOpenConfig = getUserOpenConfigPath >>= readConfigParser
-
---E.decodeUtf8With lenientDecode contents

--- a/waffle.cabal
+++ b/waffle.cabal
@@ -59,7 +59,7 @@ extra-source-files:
 
 common shared-properties
 
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall -Werror
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall -Werror -O2 -static -optc-static -optl-static -optl-pthread
 
   other-modules:
       Paths_waffle
@@ -87,6 +87,7 @@ common shared-properties
     ConfigFile           >= 1.1.4 && < 1.2,
     -- ^ I chose ConfigFile because they're on Gopherspace!le,  
     process              >= 1.6.8 && < 1.7,
+    file-embed           >= 0.0.12 && < 0.1,
 
   -- LANGUAGE extensions used by modules in this package.
   other-extensions:    OverloadedStrings


### PR DESCRIPTION
Use `file-embed` for `data/` files and change the cabal
file so standalone executables (statically linked execs)
can be used as releases.